### PR TITLE
Add undefined to sanitize option

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,8 +64,8 @@ jobs:
         run: ./scripts/test
         env:
           ARCH: "native"
-          CC: "clang"
-          CFLAGS: "-ggdb -fsanitize=address"
-          LDFLAGS: "-fsanitize=address"
+          CC: "clang -D__STRICT_ALIGNMENT"
+          CFLAGS: "-ggdb -fsanitize=address,undefined -fno-sanitize-recover=all"
+          LDFLAGS: "-fsanitize=address,undefined -fno-sanitize-recover=all"
           ENABLE_ASM: "${{ matrix.asm }}"
           CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
This PR demonstrates the failure when adding the following options.

```
          CC: "clang -D__STRICT_ALIGNMENT"
          CFLAGS: "-ggdb -fsanitize=address,undefined -fno-sanitize-recover=all"
          LDFLAGS: "-fsanitize=address,undefined -fno-sanitize-recover=all"
```

Note, in addition to the `undefined`, two more options added as:

- `-D__STRICT_ALIGNMENT` ... to ignore alignment error.
- `-f no-sanitize-recover` ... to highlight errors.