### PR TITLE
ci: enable UBSan in Linux ASan jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,8 @@ jobs:
         env:
           ARCH: "native"
           CC: "clang"
-          CFLAGS: "-ggdb -fsanitize=address"
-          LDFLAGS: "-fsanitize=address"
+          CFLAGS: "-ggdb -D__STRICT_ALIGNMENT -DOPENSSL_NO_INLINE_ASM -fsanitize=address,undefined -fno-sanitize=function"
+          LDFLAGS: "-fsanitize=address,undefined"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
           ENABLE_ASM: "${{ matrix.asm }}"
           CTEST_OUTPUT_ON_FAILURE: 1

--- a/patches/ubsan-null.patch
+++ b/patches/ubsan-null.patch
@@ -1,0 +1,65 @@
+--- crypto/asn1/a_object.c.orig	Fri Aug  8 12:30:00 2026
++++ crypto/asn1/a_object.c	Fri Aug  8 12:30:00 2026
+@@ -448,7 +448,9 @@ i2t_ASN1_OBJECT_internal(const ASN1_OBJECT *aobj, char
+ 	if (!CBB_finish(&cbb, &data, &data_len))
+ 		goto err;
+ 
+-	ret = strlcpy(buf, data, buf_len);
++	ret = (int)data_len - 1;
++	if (buf_len > 0)
++		strlcpy(buf, data, buf_len);
+  err:
+ 	CBB_cleanup(&cbb);
+ 	free(data);
+--- crypto/bn/bn_add.c.orig	Fri Aug  8 12:30:00 2026
++++ crypto/bn/bn_add.c	Fri Aug  8 12:30:00 2026
+@@ -86,9 +86,11 @@ bn_add(BN_ULONG *r, int r_len, const BN_ULONG *a, int
+ 
+ 	carry = bn_add_words(r, a, b, min_len);
+ 
+-	a += min_len;
+-	b += min_len;
+-	r += min_len;
++	if (min_len > 0) {
++		a += min_len;
++		b += min_len;
++		r += min_len;
++	}
+ 
+ 	/* XXX - consider doing four at a time to match bn_add_words(). */
+ 	while (diff_len < 0) {
+@@ -133,9 +135,11 @@ bn_sub(BN_ULONG *r, int r_len, const BN_ULONG *a, int
+ 
+ 	borrow = bn_sub_words(r, a, b, min_len);
+ 
+-	a += min_len;
+-	b += min_len;
+-	r += min_len;
++	if (min_len > 0) {
++		a += min_len;
++		b += min_len;
++		r += min_len;
++	}
+ 
+ 	/* XXX - consider doing four at a time to match bn_sub_words. */
+ 	while (diff_len < 0) {
+--- crypto/bn/bn_convert.c.orig	Fri Aug  8 12:30:00 2026
++++ crypto/bn/bn_convert.c	Fri Aug  8 12:30:00 2026
+@@ -101,3 +101,6 @@ bn_bn2binpad_internal(const BIGNUM *bn, uint8_t *out,
+ 		return -1;
+ 
++	if (out_len == 0)
++		return 0;
++
+ 	if (bn->dmax == 0) {
+--- tests/bn_convert.c.orig	Fri Aug  8 12:30:00 2026
++++ tests/bn_convert.c	Fri Aug  8 12:30:00 2026
+@@ -62,7 +62,7 @@ check_bin_output(size_t test_no, const char *label, co
+ 		    "want %d\n", test_no, label, ret, out_len);
+ 		goto failure;
+ 	}
+-	if (memcmp(out, bin, bin_len) != 0) {
++	if (bin_len > 0 && memcmp(out, bin, bin_len) != 0) {
+ 		fprintf(stderr, "FAIL: Test %zu %s - output from "
+ 		    "BN_bn2bin() differs\n", test_no, label);
+ 		fprintf(stderr, "Got:\n");


### PR DESCRIPTION
Run AddressSanitizer and UndefinedBehaviorSanitizer together.
Use strict-alignment code paths and disable known noisy function-type and inline-assembly checks.